### PR TITLE
fix magstock 6 initial deploy

### DIFF
--- a/event-magstock-development.yaml
+++ b/event-magstock-development.yaml
@@ -1,0 +1,2 @@
+---
+uber::config::prereg_open: '1999-09-09'  # fake prereg open early on dev boxes

--- a/event-magstock.yaml
+++ b/event-magstock.yaml
@@ -9,6 +9,10 @@ uber::plugins::extra_plugins:
   bands:
     git_repo: 'https://github.com/magfest/bands'
     git_branch: 'master'
+  # required by bands plugin
+  panels:
+    git_repo: 'https://github.com/magfest/panels'
+    git_branch: 'master'
 
 uber::config::numbered_badges: 'False'
 

--- a/event-magstock.yaml
+++ b/event-magstock.yaml
@@ -6,27 +6,33 @@ uber::plugins::extra_plugins:
   magstock:
     git_repo: 'https://github.com/magfest/magstock'
     git_branch: 'master'
+  bands:
+    git_repo: 'https://github.com/magfest/bands'
+    git_branch: 'master'
 
 uber::config::numbered_badges: 'False'
 
 uber::config::event_name:     'MAGStock'
-uber::config::year: 5
+uber::config::year: 6
 
 uber::config::groups_enabled: 'False'
+uber::config::kiosk_cc_enabled: True
 
-uber::config::epoch: '2015-06-19 08'
-uber::config::eschaton: '2015-06-21 18'
-uber::config::prereg_open: '2015-04-25'
-uber::config::prereg_takedown: '2015-06-15'
-uber::config::placeholder_deadline: '2015-06-16'
-uber::config::shirt_deadline: '2015-05-30'
+uber::config::epoch: '2016-06-19 08'
+uber::config::eschaton: '2016-06-21 18'
+uber::config::prereg_open: '2016-04-25'
+uber::config::prereg_takedown: '2016-06-15'
+uber::config::placeholder_deadline: '2016-06-16'
+uber::config::shirt_deadline: '2016-05-30'
+uber::config::supporter_deadline: '2016-05-31'
 uber::config::printed_badge_deadline: ''
 uber::config::dealer_reg_start: ''
-uber::config::uber_takedown: '2015-06-17'
+uber::config::uber_takedown: '2016-06-17'
 
-uber::config::max_badge_sales: 500
+uber::config::max_badge_sales: 600
 
-uber::config::at_the_con: 'True'
+uber::config::at_the_con: 'False'
+uber::config::post_con: 'False'
 
 uber::config::donation_tier:
   - "'No thanks'      = 0"
@@ -34,13 +40,11 @@ uber::config::donation_tier:
   - "'Supporter Pack' = SUPPORTER_LEVEL"
 
 uber::config::badge_enums:
-  attendee_badge:         "Attendee"
-  supporter_badge:        "Supporter"
-  staff_badge:            "Staff"
-  guest_badge:            "Guest"
-  one_day_badge:          "One Day"
-
-uber::config::supporter_deadline: '2015-05-31'
+        attendee_badge:         "Attendee"
+        supporter_badge:        "Supporter"
+        staff_badge:            "Staff"
+        guest_badge:            "Guest"
+        one_day_badge:          "One Day"
 
 # prereg form UI options
 uber::config::donations_enabled: true
@@ -49,7 +53,7 @@ uber::config::consent_form_url: ""
 
 uber::config::badge_types:
   staff_badge:
-    range_start: 1
+    range_start: 152
     range_end: 999
   supporter_badge:
     range_start: 1000
@@ -72,7 +76,7 @@ uber::config::badge_prices:
     - { 'Sunday': 40 }
     - { 'Monday': 30 }
   attendee:
-    - { '2015-06-16': 65 }
+    - { '2016-06-16': 65 }
 
 uber::config::job_interests:
   cat_herding: "Cat Herding"

--- a/event-magstock.yaml
+++ b/event-magstock.yaml
@@ -6,13 +6,14 @@ uber::plugins::extra_plugins:
   magstock:
     git_repo: 'https://github.com/magfest/magstock'
     git_branch: 'master'
-  bands:
-    git_repo: 'https://github.com/magfest/bands'
-    git_branch: 'master'
+  # magstock wants these but they need some config work. TODO
+  #bands:
+  #  git_repo: 'https://github.com/magfest/bands'
+  #  git_branch: 'master'
   # required by bands plugin
-  panels:
-    git_repo: 'https://github.com/magfest/panels'
-    git_branch: 'master'
+  #panels:
+  #  git_repo: 'https://github.com/magfest/panels'
+  #  git_branch: 'master'
 
 uber::config::numbered_badges: 'False'
 


### PR DESCRIPTION
First shot at a working magstock 6 deploy, untested, needs LOTS of tweaking as all values are mostly copy/paste from last year with dates set one year later.

related to: https://github.com/magfest/simple-rams-deploy/pull/9
