### PR TITLE
Fix magstock deploy

### DIFF
--- a/event-magstock.yaml
+++ b/event-magstock.yaml
@@ -144,3 +144,17 @@ uber::config::interest_list:
   video_games:  'Video Games'
   moonbounce:   'Moonbounce'
   activities:   'Activities'
+
+uber::config::volunteer_checklist:
+  4: 'signups/shifts_item.html'
+
+uber::config::dept_head_checklist:
+  creating_shifts:
+    deadline: "2016-04-12"
+    description: "STOPS is happy to assist you in creating shifts. Since the days of the week are different than M13, we recomend only using M13 as a simple guideline.  Please let us know if you need assistance with this step."
+    path: "/jobs/index?location={department}"
+  assigned_volunteers:
+    name: "Volunteers Assigned to Your Department"
+    deadline: "2015-05-01"
+    description: "Check all of the volunteers currently assigned to your department to make sure no one is missing AND that no one is there who shouldn't be."
+    path: "/jobs/staffers?location={department}"

--- a/external/stage.uber.magfest.org.yaml
+++ b/external/stage.uber.magfest.org.yaml
@@ -1,5 +1,7 @@
 ---
 
-# force stage1 to be in at the con mode for testing
-# uber::config::at_the_con: 'True'
-# uber::config::post_con: 'False'
+# open prereg early on this particular server
+# so we can test before prereg really opens
+# uber::config::prereg_open: '2015-08-13'
+
+test_only_ignore_this: True


### PR DESCRIPTION
Trying to deploy magstock to a staging server for the first time today, fixing:
1) stage.uber.magfest.org was legit busted (YAML is so picky about syntax)
2) magstock missing dept checklist stuff, making folks trying to work on jobs.py related stuff getting errors
