### PR TITLE
change name to 'magfest laboratories'

### DIFF
--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -26,7 +26,7 @@ uber::plugins::extra_plugins:
 uber::config::priority_plugins: "uber, panels"
 
 # event settings
-uber::config::event_name: 'MAGLabs'
+uber::config::event_name: 'MAGFest Laboratories'
 uber::config::year: 2016
 
 uber::config::groups_enabled: 'True'


### PR DESCRIPTION
Change Event name to actual event name of MAGFest Laboratories instead of MAGLabs
