### PR TITLE
Turn on MOST OF THE PLUGINS for labs and prime

### DIFF
--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -165,6 +165,9 @@ uber::config::event_locations:
   tabletop_ccg: "Tabletop (CCG)"
   pentathlon: "MAGOlympics Pentathlon"
 
+# entries here must also exist in event_locations
+uber::plugin_panels::panel_rooms: "panels_1,panels_2,panels_3"   # empty list
+
 uber::config::shirt_level: 20
 uber::config::supporter_level: 50
 uber::config::season_level: 160

--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -166,7 +166,7 @@ uber::config::event_locations:
   pentathlon: "MAGOlympics Pentathlon"
 
 # entries here must also exist in event_locations
-uber::plugin_panels::panel_rooms: "panels_1,panels_2,panels_3"   # empty list
+uber::plugin_panels::panel_rooms: "panels_1,panels_2,panels_3"
 
 uber::config::shirt_level: 20
 uber::config::supporter_level: 50

--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -4,18 +4,15 @@ classes:
 - uber::plugin_panels
 - uber::plugin_bands
 - uber::plugin_hotel
+- uber::plugin_tabletop
 
 uber::plugins::extra_plugins:
   magclassic:
     git_repo: 'https://github.com/magfest/magclassic'
     git_branch: 'master'
-# TODO: maglabs (likely) wants these plugins, however, they may need to be updated from last year
-#  attendee_tournaments:
-#    git_repo: 'https://github.com/magfest/attendee_tournaments'
-#    git_branch: 'master'
-#  tabletop:
-#    git_repo: 'https://github.com/magfest/tabletop'
-#    git_branch: 'master'
+  attendee_tournaments:
+    git_repo: 'https://github.com/magfest/attendee_tournaments'
+    git_branch: 'master'
 
 uber::config::priority_plugins: "uber, panels"
 

--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -1,23 +1,17 @@
 ---
 classes:
 - roles::uber_server
+- uber::plugin_panels
+- uber::plugin_bands
+- uber::plugin_hotel
 
 uber::plugins::extra_plugins:
   magclassic:
     git_repo: 'https://github.com/magfest/magclassic'
     git_branch: 'master'
 # TODO: maglabs (likely) wants these plugins, however, they may need to be updated from last year
-#  hotel:
-#    git_repo: 'https://github.com/magfest/hotel'
-#    git_branch: 'master'
-#  panels:
-#    git_repo: 'https://github.com/magfest/panels'
-#    git_branch: 'master'
 #  attendee_tournaments:
 #    git_repo: 'https://github.com/magfest/attendee_tournaments'
-#    git_branch: 'master'
-#  bands:
-#    git_repo: 'https://github.com/magfest/bands'
 #    git_branch: 'master'
 #  tabletop:
 #    git_repo: 'https://github.com/magfest/tabletop'
@@ -53,7 +47,7 @@ uber::config::dealer_payment_due: '2016-09-01'        # dealers must pay by this
 
 uber::config::max_badge_sales: 2000
 
-uber::config::hide_schedule: 'True'
+uber::plugin_panels::hide_schedule: 'True'
 
 uber::config::at_the_con: 'False'
 
@@ -185,7 +179,7 @@ uber::config::interest_list:
   dealers: "Dealers"
   tournaments: "Tournaments"
 
-uber::config::hotel_req_hour: 24
+uber::plugin_hotel::hotel_req_hours: 24
 
 uber::config::volunteer_checklist:
   4: 'hotel_requests/hotel_item.html'

--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -1,6 +1,9 @@
 ---
 classes:
 - roles::uber_server
+- uber::plugin_panels
+- uber::plugin_bands
+- uber::plugin_hotel
 
 # magfest prime event-specific settings
 
@@ -8,20 +11,11 @@ uber::plugins::extra_plugins:
   magprime:
     git_repo: 'https://github.com/magfest/magprime'
     git_branch: 'master'
-  hotel:
-    git_repo: 'https://github.com/magfest/hotel'
-    git_branch: 'master'
-  panels:
-    git_repo: 'https://github.com/magfest/panels'
-    git_branch: 'master'
   mivs:
     git_repo: 'https://github.com/magfest/mivs'
     git_branch: 'master'
   attendee_tournaments:
     git_repo: 'https://github.com/magfest/attendee_tournaments'
-    git_branch: 'master'
-  bands:
-    git_repo: 'https://github.com/magfest/bands'
     git_branch: 'master'
   tabletop:
     git_repo: 'https://github.com/magfest/tabletop'
@@ -29,7 +23,8 @@ uber::plugins::extra_plugins:
 
 uber::config::priority_plugins: "uber, panels"
 
-uber::config::hotel_req_hour: 30
+uber::plugin_hotel::hotel_req_hours: 24
+
 uber::config::room_deadline: '2016-01-05'
 
 uber::config::groups_enabled: True
@@ -63,7 +58,8 @@ uber::config::dealer_payment_due: '2016-01-02'        # dealers must pay by this
 
 uber::config::max_badge_sales: 20000
 
-uber::config::hide_schedule: 'False'
+uber::plugin_panels::hide_schedule: 'True'
+
 uber::config::at_the_con: 'False'
 uber::config::post_con: 'True'
 

--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -4,6 +4,7 @@ classes:
 - uber::plugin_panels
 - uber::plugin_bands
 - uber::plugin_hotel
+- uber::plugin_tabletop
 
 # magfest prime event-specific settings
 
@@ -16,9 +17,6 @@ uber::plugins::extra_plugins:
     git_branch: 'master'
   attendee_tournaments:
     git_repo: 'https://github.com/magfest/attendee_tournaments'
-    git_branch: 'master'
-  tabletop:
-    git_repo: 'https://github.com/magfest/tabletop'
     git_branch: 'master'
 
 uber::config::priority_plugins: "uber, panels"


### PR DESCRIPTION
Turn on the hotel, bands, panels, tabletop, and attendee_tournaments plugin for maglabs (currently running) and magprime (to be running later this year)

Clean up some obsolete INI settings that used to live in uber plugin's development.ini but now live in hotel/panels INI files.

once this is merged, also merge https://github.com/magfest/production-config/pull/25
