### PR TITLE
Changes Epoch to Thurs 6/16

### DIFF
--- a/event-magstock.yaml
+++ b/event-magstock.yaml
@@ -20,7 +20,7 @@ uber::config::event_venue_address: '4400 Byrd Mill Road, Louisa, VA 23093'
 uber::config::groups_enabled: 'False'
 uber::config::kiosk_cc_enabled: True
 
-uber::config::epoch: '2016-06-17 08'
+uber::config::epoch: '2016-06-16 18'
 uber::config::eschaton: '2016-06-19 18'
 uber::config::prereg_open: '2016-04-29 10'
 uber::config::prereg_takedown: '2016-06-12'


### PR DESCRIPTION
Stock Admin wants Thurs to be an official evening, this change reflects the Epoch going from Fri morning to Thurs evening.
(Should open up schedule options.)
