### PR TITLE
add INI settings for band merch configurability

### DIFF
--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -251,3 +251,8 @@ uber::plugin_bands::band_merch_deadline:      '2016-08-01 08'
 uber::plugin_bands::band_charity_deadline:    '2016-09-05 08'
 uber::plugin_bands::band_badge_deadline:      '2016-08-10 08'
 uber::plugin_bands::stage_agreement_deadline: '2016-08-15 08'
+
+uber::plugin_bands::band_merch_enums:
+  no_merch:     "Not selling merch"
+  own_table:    "Dedicated table"
+  rock_island:  "Rock Island" # enable rock island

--- a/event-magstock.yaml
+++ b/event-magstock.yaml
@@ -174,3 +174,5 @@ uber::plugin_bands::band_merch_deadline:      '2016-06-05 08'
 uber::plugin_bands::band_charity_deadline:    ''  # disabled for magstock
 uber::plugin_bands::band_badge_deadline:      '2016-06-10 08'
 uber::plugin_bands::stage_agreement_deadline: '2016-06-05 08'
+
+uber::plugin_bands::require_dedicated_band_table_presence: false

--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -341,3 +341,21 @@ uber::config::dept_head_checklist:
     description: "After the weekend is over, we'll want all department heads to ensure that their volunteers had their shifts marked and rated."
     path: "/jobs/signups?location=59983785"
 
+uber::plugin_bands::band_email:           'MAGFest Music Department <music@magfest.org>'
+uber::plugin_bands::band_email_signature: '- MAGFest Music Department'
+
+uber::plugin_bands::auction_start:            '2016-09-11 11' # placeholder
+
+uber::plugin_bands::band_panel_deadline:      '2016-08-01 08' # placeholder
+uber::plugin_bands::band_bio_deadline:        '2016-07-01 08' # placeholder
+uber::plugin_bands::band_agreement_deadline:  '2016-06-25 08' # placeholder
+uber::plugin_bands::band_w9_deadline:         '2016-07-25 08' # placeholder
+uber::plugin_bands::band_merch_deadline:      '2016-08-01 08' # placeholder
+uber::plugin_bands::band_charity_deadline:    '2016-09-05 08' # placeholder
+uber::plugin_bands::band_badge_deadline:      '2016-08-10 08' # placeholder
+uber::plugin_bands::stage_agreement_deadline: '2016-08-15 08' # placeholder
+
+uber::plugin_bands::band_merch_enums:
+  no_merch:     "Not selling merch"
+  own_table:    "Dedicated table"
+  rock_island:  "Rock Island" # enable rock island


### PR DESCRIPTION
- band_merch_enums to turn on/off rock island per-event
- require_dedicated_band_table_presence to turn off the requirement that bands be required to man their table for 8 hours per day
