### PR TITLE
Updated text of DH checklist to have a deadline of 6-6-16

### DIFF
--- a/event-magstock.yaml
+++ b/event-magstock.yaml
@@ -152,7 +152,7 @@ uber::config::volunteer_checklist:
 
 uber::config::dept_head_checklist:
   creating_shifts:
-    deadline: "2016-06-1"
+    deadline: "2016-06-6"
     description: "The managment team is happy to assist you in creating shifts. Please let us know if you need assistance with this step."
     path: "/jobs/index?location={department}"
   assigned_volunteers:


### PR DESCRIPTION
Looking at line #34: uber::config::shifts_created: '2016-06-6'
The DH Checklist is set to go out 7 days prior to that deadline
Looking at line #155: deadline: "2016-06-1" This deadling conflicts with that.
I am not sure why they are different. Changing the 2nd one to be 6/6 so we can get this email out to the DH's
