### PR TITLE
Disable permission slip notices for MAGLabs

### DIFF
--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -69,6 +69,7 @@ uber::config::badge_enums:
 
 # prereg form UI options
 uber::config::donations_enabled: true
+uber::config::consent_form_url: ""
 
 uber::config::badge_types:
   staff_badge:


### PR DESCRIPTION
MAGLabs doesn't need the permission slip info, so we're disabling it via config.
