### PR TITLE
Update takedown dates for Labs

### DIFF
--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -30,9 +30,9 @@ uber::config::epoch: '2016-09-09 08'
 uber::config::eschaton: '2016-09-11 18'
 
 uber::config::prereg_open: '2016-06-02'
-uber::config::prereg_takedown: '2016-09-10'
-uber::config::group_prereg_takedown: '2016-09-10'
-uber::config::uber_takedown: '2016-09-10'
+uber::config::prereg_takedown: '2016-09-08'
+uber::config::group_prereg_takedown: '2016-09-08'
+uber::config::uber_takedown: '2016-09-11'
 
 uber::config::placeholder_deadline: '2016-09-09'
 uber::config::supporter_deadline: '2016-08-20'


### PR DESCRIPTION
Set the prereg takedown dates to the day before the event starts instead of the day after. Sets uber_takedown to the end of the event since the system does not actually go down.

Fixes https://github.com/magfest/magclassic/issues/29. Requires https://github.com/magfest/magclassic/pull/34, https://github.com/magfest/hotel/pull/47/files, and https://github.com/magfest/ubersystem/pull/1835 to work properly (else it'll mess up email timing).
