### PR TITLE
Changing Job Interest and locations to reflect update things

### DIFF
--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -116,7 +116,7 @@ uber::config::job_interests:
   tournaments: "Tournaments"
   jamspace: "Jamspace"
   staff_suite: "Staff Suite"
-
+  
 uber::config::job_locations:
   console: "Consoles"
   arcade: "Arcade"
@@ -133,7 +133,7 @@ uber::config::job_locations:
   staff_suite: "Staff Suite"
   marketplace: "Marketplace"
   stops: "Stops"
-  fest_ops: "Fest Ops"
+  fest_ops: "Guest"
   charity: "Charity"
   dorsai: "Dorsai"
   mops: "Mediatron!"

--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -111,7 +111,6 @@ uber::config::job_interests:
   tabletop: "Tabletop Games"
   loading_crew: "Loading Crew"
   registration: "Registration"
-  bridge_simulator: "Starship Horizons"
   techops: "Tech Ops / AV"
   lan: "LAN"
   tournaments: "Tournaments"
@@ -136,7 +135,6 @@ uber::config::job_locations:
   stops: "Stops"
   fest_ops: "Fest Ops"
   charity: "Charity"
-  dispatch: "Dispatch"
   dorsai: "Dorsai"
   mops: "Mediatron!"
   merch: "Merchandise"
@@ -148,8 +146,6 @@ uber::config::job_locations:
   tea_room: "Tea Room"
   treasury: "Treasury"
   concert_security: "Concert Security"
-  lan_events: "LAN Events"
-  rock_island: "Rock Island"
 
 uber::config::shiftless_depts: "dorsai, bridge_simulator, marketplace"
 


### PR DESCRIPTION
--Dispatch had 0 staffers for Classic, that should be absorbed by Stops and/or Tech Ops.
-- Lan Events is being rolled back into LAN as a department / group.
-- Rock Island as a department will more than likely not exist at Classic.
-- Star Ship Horizons shouldn't be a Job Interest as a general volunteer won't be able to staff their area.
- Also added Guest in place of Fest Ops.
