### PR TITLE
fix volunteer checklist for magstock

### DIFF
--- a/event-magstock.yaml
+++ b/event-magstock.yaml
@@ -148,7 +148,9 @@ uber::config::interest_list:
   activities:   'Activities'
 
 uber::config::volunteer_checklist:
-  4: 'signups/shifts_item.html'
+  2: 'signups/shifts_item.html'
+  3: ''   # need to leave blank for magstock to work - skip food allergies
+  4: ''   # need to leave blank for magstock to work - skip shirt sizes
 
 uber::config::dept_head_checklist:
   creating_shifts:


### PR DESCRIPTION
- override shifts_item.html to have prerequisite only be placeholder, nothing else
- set other steps in dept head checklist to empty strings to disable them for magstock

merge with https://github.com/magfest/magstock/pull/78
