### PR TITLE
change food cap to reflect new logic

### DIFF
--- a/event-magstock.yaml
+++ b/event-magstock.yaml
@@ -131,7 +131,7 @@ uber::config::coming_as_types:
 # number of people allowed to buy meals.
 # this number does NOT include people who get free meals automatically like: staff badges, performers, and their +1s
 # the amount of meals we need to serve may end up ~40 higher than this number.
-uber::config::food_stock: 130       # only affects MAGSTOCK instances
+uber::config::food_stock: 101       # only affects MAGSTOCK instances
 uber::config::food_price: 20        # only affects MAGSTOCK instances
 
 uber::config::supporter_stock: 50


### PR DESCRIPTION
Previously food cap was calculated from everyone who was going to be receiving food, including free food
New food cap is JUST those paying for it.  AS a result we need to reduce the number shown here from 130 (original amount)

101 is the amount of people paying for food right now, so setting the cap to that so no one else can buy food.  Next year feel free to set this to whatever next year.
