### PR TITLE
set magstock to post-con mode

### DIFF
--- a/event-magstock.yaml
+++ b/event-magstock.yaml
@@ -37,8 +37,8 @@ uber::config::uber_takedown: '2016-06-16'
 uber::config::max_badge_sales: 550
   # review this as we get closer to cap
 
-uber::config::at_the_con: 'True'
-uber::config::post_con: 'False'
+uber::config::at_the_con: 'False'
+uber::config::post_con: 'True'
 
 uber::config::donation_tier:
   - "'No thanks'      = 0"


### PR DESCRIPTION
I think this should do the trick.

To avoid sending confirmation emails we need to set at least one of AT_THE_CON or POST_CON to True.
