### PR TITLE
Centralized logging

### DIFF
--- a/production.yaml
+++ b/production.yaml
@@ -3,3 +3,7 @@
 # enable our logs to be sent to a centralized server for processing later
 # note: the magfest logging host currently only accepts whitelisted IPs
 uber::log-filebeat::server_name_and_port:  'docker.magfest.net:9200'
+
+# tell our logs to always indent multiline log output.  this makes it easier to parse them later
+# in external log processing apps for multiline things like tracebacks.
+uber::config::log_force_multiline_indent: True

--- a/production.yaml
+++ b/production.yaml
@@ -1,3 +1,5 @@
 # production-specific overrides
 ---
-placeholder_only: "Just a placeholder needed to make puppet happy, when real content is added, feel free to remove it."
+# enable our logs to be sent to a centralized server for processing later
+# note: the magfest logging host currently only accepts whitelisted IPs
+uber::log-filebeat::server_name_and_port:  'docker.magfest.net:9200'


### PR DESCRIPTION
Turn on centralized logging suppor for any of our production servers.

Note: Production servers have to be explicitly whitelisted by the firewall on the logging server, so this is not the only step to turning them on.

Merge after: 
- https://github.com/magfest/sideboard/pull/17
- https://github.com/magfest/ubersystem-puppet/pull/92
