### PR TITLE
fix variable names to go with newly upgraded nginx

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -1,7 +1,7 @@
 ---
 
-uber::nginx::ssl_crt_bundle:  'puppet:///modules/uber/magfest.org.new.crt-bundle'
-uber::nginx::ssl_crt_key:     'puppet:///modules/uber/magfest.org.new.key'
+uber::nginx::ssl_crt:  'puppet:///modules/uber/magfest.org.new.crt-bundle'
+uber::nginx::ssl_key:  'puppet:///modules/uber/magfest.org.new.key'
 
 # event settings
 uber::config::organization_name:  'MAGFest INC'

--- a/vagrant-1.yaml
+++ b/vagrant-1.yaml
@@ -1,8 +1,8 @@
 # magfest-specific
 # vagrant settings for all magfest events
 ---
-uber::nginx::ssl_crt_bundle:      'puppet:///modules/uber/selfsigned-testonly.crt'
-uber::nginx::ssl_crt_key:         'puppet:///modules/uber/selfsigned-testonly.key'
+uber::nginx::ssl_crt:      'puppet:///modules/uber/selfsigned-testonly.crt'
+uber::nginx::ssl_key:      'puppet:///modules/uber/selfsigned-testonly.key'
 
 # selfsigned-X are for *LOCAL* DEVELOPMENT only, never use these on any kind of public server
 uber::nginx::ssl_ca_crt:     "puppet:///modules/uber/selfsigned-X-ca.crt"


### PR DESCRIPTION
after we upgrade our nginx puppet module, the fixes require these changes.

merge AFTER https://github.com/magfest/ubersystem-puppet/pull/93
