### PR TITLE
Update Table prices for Labs

### DIFF
--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -90,8 +90,15 @@ uber::config::badge_types:
 
 uber::config::initial_attendee: 40    # badge price
 uber::config::dealer_badge_price: 20
-uber::config::default_table_price: 80
-uber::config::max_dealers: 8
+uber::config::max_dealers: 10
+uber::config::default_table_price: 225
+
+uber::config::table_prices:
+  1: 80
+  2: 115
+  3: 160
+  4: 225
+
 uber::config::badge_prices:
   single_day:
     - { 'Friday': 30 }


### PR DESCRIPTION
Staging Server pulled data from standard config for dealer tables, 
This should over ride that data. Labs tables are going to less that Fest since it shorter and less people.
