### PR TITLE
fixup dates and settings for magprime 2017, first pass

### DIFF
--- a/event-magstock-development.yaml
+++ b/event-magstock-development.yaml
@@ -1,3 +1,3 @@
 ---
 uber::config::prereg_open: '1999-09-09'  # fake prereg open early on dev boxes
-uber::config::food_stock: 0 # set this to zero to test out when food cap is hit
+# uber::config::food_stock: 0 # set this to zero to test out when food cap is hit

--- a/event-prime-development.yaml
+++ b/event-prime-development.yaml
@@ -1,0 +1,2 @@
+---
+uber::config::prereg_open: '1999-09-09'  # fake prereg open early on dev boxes

--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -23,12 +23,12 @@ uber::config::priority_plugins: "uber, panels, bands"
 
 uber::plugin_hotel::hotel_req_hours: 24
 
-uber::config::room_deadline: '2016-01-05'
+uber::config::room_deadline: '2016-11-21'
 
 uber::config::groups_enabled: True
 
 uber::config::event_name: 'MAGFest'
-uber::config::year: 2016
+uber::config::year: 2017
 
 uber::config::event_venue: 'The Gaylord National Hotel and Convention Center'
 uber::config::event_venue_address: '201 Waterfront St, National Harbor, MD 20745'
@@ -37,32 +37,32 @@ uber::config::peglegs_sig: |
     - Tom Hyre,
     MAGFest Director of Panel Operations
 
-uber::config::epoch: '2016-02-18 08'
-uber::config::eschaton: '2016-02-21 18'
+uber::config::epoch: '2017-01-05 08'
+uber::config::eschaton: '2017-01-08 18'
 
-uber::config::prereg_open: '2015-09-01 17'
-uber::config::prereg_takedown: '2016-02-16'
-uber::config::group_prereg_takedown: '2016-02-16'
-uber::config::uber_takedown: '2016-02-17'
+uber::config::prereg_open: '2016-08-10 17'
+uber::config::prereg_takedown: '2017-01-03'
+uber::config::group_prereg_takedown: '2017-01-03'
+uber::config::uber_takedown: '2017-01-07'
 
-uber::config::placeholder_deadline: '2016-02-12'
-uber::config::supporter_deadline: '2016-01-13'
-uber::config::shirt_deadline: '2016-02-12'
-uber::config::printed_badge_deadline: '2016-01-20'
+uber::config::placeholder_deadline: '2016-12-26'
+uber::config::supporter_deadline: '2016-11-29'
+uber::config::shirt_deadline: '2016-12-15'
+uber::config::printed_badge_deadline: '2016-12-05'
 
-uber::config::shifts_created: '2015-11-26'
+uber::config::shifts_created: '2016-10-26'
 
-uber::config::dealer_reg_start: '2015-07-31 19'       # dealer reg not allowed before this date
-uber::config::dealer_reg_deadline: '2015-08-02 03'    # after this date, applications are auto-waitlisted
-uber::config::dealer_reg_shutdown: '2015-08-04'       # after this date, no new applications allowed
-uber::config::dealer_payment_due: '2016-01-02'        # dealers must pay by this date
+uber::config::dealer_reg_start: '2016-07-31 19'       # dealer reg not allowed before this date
+uber::config::dealer_reg_deadline: '2016-08-15 03'    # after this date, applications are auto-waitlisted
+uber::config::dealer_reg_shutdown: '2016-08-18'       # after this date, no new applications allowed
+uber::config::dealer_payment_due: '2016-11-15'        # dealers must pay by this date
 
 uber::config::max_badge_sales: 20000
 
 uber::plugin_panels::hide_schedule: 'True'
 
 uber::config::at_the_con: 'False'
-uber::config::post_con: 'True'
+uber::config::post_con: 'False'
 
 uber::config::donation_tier:
     - "'No thanks'      = 0"
@@ -288,74 +288,74 @@ uber::config::dept_head_overrides:
 
 uber::config::dept_head_checklist:
   creating_shifts:
-    deadline: "2015-11-17"
+    deadline: "2016-10-17"
     description: "STOPS is happy to assist you in creating shifts. Since the days of the week are different than M13, we recomend only using M13 as a simple guideline.  Please let us know if you need assistance with this step."
     path: "/jobs/index?location={department}"
   assigned_volunteers:
     name: "Volunteers Assigned to Your Department"
-    deadline: "2015-12-01"
+    deadline: "2016-11-01"
     description: "Check all of the volunteers currently assigned to your department to make sure no one is missing AND that no one is there who shouldn't be."
     path: "/jobs/staffers?location={department}"
   treasury:
     name: "MPoint Needs"
-    deadline: "2015-12-15"
+    deadline: "2016-11-15"
     description: "Tell us whether you need any mpoints for your department."
     path: "/magprime_dept_checklist/treasury"
   allotments:
     name: "Treasury Information"
-    deadline: "2015-12-15"
+    deadline: "2016-11-15"
     description: "If you need cash and/or mpoints, tell us your department schedule and your specific cash needs."
     path: "/magprime_dept_checklist/allotments"
   approve_setup_teardown:
     name: "Approve/Decline Requests to Help With Setup/Teardown"
-    deadline: "2015-12-22"
+    deadline: "2016-11-22"
     description: "An overwhelming majority of staffers want to work setup and teardown shifts rather than work during the event itself, so we have far more offers than we have need for.  Since this affects what hotel nights staffers get, please approve and decline requests for this for people in your department."
     path: "/hotel/requests?department={department}"
   hotel_eligible:
     name: "Staffers Requesting Hotel Space"
-    deadline: "2015-12-29"
+    deadline: "2016-11-29"
     description: "Double check that everyone in your department who you know needs hotel space has requested it."
     path: "/hotel/index?department={department}"
   printed_signs:
-    deadline: "2016-01-05"
+    deadline: "2016-12-05"
     description: "Other than a sign for your area, what printed signs/banners/forms do you need?"
   office_supplies:
-    deadline: "2016-01-05"
+    deadline: "2016-12-05"
     description: "Do you need any paper, pens, sharpies, tripods, whiteboards, scissors, staplers, etc?"
   custom_ribbons:
-    deadline: "2016-01-05"
+    deadline: "2016-12-05"
     description: "Besides the ribbons given out at registration, you may need your own ribbon type to help manage access to certain restricted areas. If so, please let us know what they should say, how many you'll need, and what color you'd like them to be. These ribbons will be given to you at the beginning of MAGFest to distribute to whoever needs them.  (Note: Small orders of ribbons are very expensive - please request a ribbon type only if you need it, and tell us why you need it so we can make sure there's no duplication between departments.)"
   placeholders:
     name: "Checking Placeholder Registrations"
-    deadline: "2015-12-22"
+    deadline: "2016-11-22"
     description: "We create placeholder registrations for volunteers and ask them to fill out the rest of their information and also confirm that they'll be coming.  We need our department heads to review the unclaimed badges for their departments to check for any essential volunteers who haven't claimed their badges."
     path: "/registration/placeholders?department={department}"
   tech_requirements:
     name: "Tech Requirements"
-    deadline: "2015-12-29"
+    deadline: "2016-11-29"
     description: "What do you need in terms of laptops, projectors, cables, internet access, etc?"
     path: "/magprime_dept_checklist/tech_requirements"
   postcon_hours:
     name: "(After the Event) Marking and Rating Shifts"
-    deadline: "2016-03-01"
+    deadline: "2017-02-01"
     description: "After the weekend is over, we'll want all department heads to ensure that their volunteers had their shifts marked and rated."
     path: "/jobs/signups?location=59983785"
 
 uber::plugin_bands::band_email:           'MAGFest Music Department <music@magfest.org>'
 uber::plugin_bands::band_email_signature: '- MAGFest Music Department'
 
-uber::plugin_bands::auction_start:            '2016-09-11 11' # placeholder
+uber::plugin_bands::auction_start:            '2017-01-08 11' # placeholder
 
-uber::plugin_bands::band_panel_deadline:      '2016-08-01 08' # placeholder
-uber::plugin_bands::band_bio_deadline:        '2016-07-01 08' # placeholder
-uber::plugin_bands::band_agreement_deadline:  '2016-06-25 08' # placeholder
-uber::plugin_bands::band_w9_deadline:         '2016-07-25 08' # placeholder
-uber::plugin_bands::band_merch_deadline:      '2016-08-01 08' # placeholder
-uber::plugin_bands::band_charity_deadline:    '2016-09-05 08' # placeholder
-uber::plugin_bands::band_badge_deadline:      '2016-08-10 08' # placeholder
-uber::plugin_bands::stage_agreement_deadline: '2016-08-15 08' # placeholder
+uber::plugin_bands::band_panel_deadline:      '2016-11-01 08'
+uber::plugin_bands::band_bio_deadline:        '2016-09-01 08'
+uber::plugin_bands::band_agreement_deadline:  '2016-09-25 08'
+uber::plugin_bands::band_w9_deadline:         '2016-09-25 08'
+uber::plugin_bands::band_merch_deadline:      '2016-10-01 08'
+uber::plugin_bands::band_charity_deadline:    '2016-11-05 08'
+uber::plugin_bands::band_badge_deadline:      '2016-10-10 08'
+uber::plugin_bands::stage_agreement_deadline: '2016-10-15 08'
 
 uber::plugin_bands::band_merch_enums:
   no_merch:     "Not selling merch"
   own_table:    "Dedicated table"
-  rock_island:  "Rock Island" # enable rock island
+  rock_island:  "Rock Island" # comment out this line to disable rock island in band agreement / plugin


### PR DESCRIPTION
- setting semi-reasonable guesses at dates for next year
- set post-con mode to false

CC'ing @bds002 though the dates don't have to be perfect right now, just a reasonable first guess.  I mostly subtracted about 1.5 months from all the dates.  A bunch of these can probably be moved up since we did things later in the game last year.

magprime deploy seems to be behaving pretty well without much modification, which is awesome :)
