### PR TITLE
enable new magfest common events plugin

### DIFF
--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -5,6 +5,7 @@ classes:
 - uber::plugin_bands
 - uber::plugin_hotel
 - uber::plugin_tabletop
+- uber::plugin_magfest
 
 uber::plugins::extra_plugins:
   magclassic:
@@ -187,21 +188,39 @@ uber::config::volunteer_checklist:
   4: 'hotel_requests/hotel_item.html'
   5: 'signups/shifts_item.html'
 
+# TODO: changeme: these are the same forms as magprime 2016 (last year)
+uber::plugin_magfest::treasury_dept_checklist_form_url:   "https://docs.google.com/spreadsheets/d/1v-jZ7NPIgpR0-wsfZFOTKJJbKDUrd-xVIgf0mTTbjtM/edit#gid=799868163"
+uber::plugin_magfest::techops_dept_checklist_form_url:    "https://magops.wufoo.com/forms/tech-requirements-form/"
+
 uber::config::dept_head_checklist:
   creating_shifts:
-    deadline: "2016-08-22"
+    deadline: "2016-08-06"
     description: "STOPS is happy to assist you in creating shifts, if you aren't making any changes, we can use the shifts from M8.5.  Please let us know if you need assistance with this step or what changes you have."
     path: "/jobs/index?location={department}"
   assigned_volunteers:
     name: "Volunteers Assigned to Your Department"
-    deadline: "2016-08-22"
+    deadline: "2016-08-06"
     description: "Check all of the volunteers currently assigned to your department to make sure no one is missing AND that no one is there who shouldn't be."
     path: "/jobs/staffers?location={department}"
+  treasury:
+    name: "MPoint Needs"
+    deadline: "2016-08-06"
+    description: "Tell us whether you need any mpoints for your department."
+    path: "/magfest_dept_checklist/treasury"
+  allotments:
+    name: "Treasury Information"
+    deadline: "2016-08-06"
+    description: "If you need cash and/or mpoints, tell us your department schedule and your specific cash needs."
+    path: "/magfest_dept_checklist/allotments"
   hotel_eligible:
     name: "Staffers Requesting Hotel Space"
-    deadline: "2016-08-26"
+    deadline: "2016-08-12"
     description: "Double check that everyone in your department who you know needs hotel space has requested it."
     path: "/hotel/index?department={department}"
+  tech_requirements:
+    deadline: "2016-08-12"
+    description: "What do you need in terms of laptops, projectors, cables, internet access, etc?"
+    path: "/magfest_dept_checklist/tech_requirements"
   approve_setup_teardown:
     name: "Approve/Decline Requests to Help With Setup/Teardown"
     deadline: "2016-08-26"
@@ -218,20 +237,11 @@ uber::config::dept_head_checklist:
   office_supplies:
     deadline: "2016-09-06"
     description: "Do you need any paper, pens, sharpies, tripods, whiteboards, scissors, staplers, etc?"
-  treasury:
-    name: "Cash / MPoint Needs"
-    deadline: "2016-09-06"
-    description: "Tell us whether you need any cash/mpoints for your department."
-    path: "/treasury/allotments"
   postcon_hours:
     name: "(After the Event) Marking and Rating Shifts"
     deadline: "2016-09-18"
     description: "After the weekend is over, we'll want all department heads to ensure that their volunteers had their shifts marked and rated."
     path: "/jobs/signups?location=59983785"
-  tech_requirements:
-    deadline: "2016-09-02"
-    description: "What do you need in terms of laptops, projectors, cables, internet access, etc?"
-    path: "/techops/tech_requirements"
 
 uber::plugin_panels::panel_rooms: "panels_1,panels_2,panels_3"
 uber::plugin_panels::hide_schedule: true

--- a/event-magstock.yaml
+++ b/event-magstock.yaml
@@ -3,6 +3,7 @@ classes:
 - roles::uber_server
 - uber::plugin_panels
 - uber::plugin_bands
+- uber::plugin_magfest
 
 uber::plugins::extra_plugins:
   magstock:

--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -1,17 +1,15 @@
 ---
+# magfest prime event-specific settings
+
 classes:
 - roles::uber_server
 - uber::plugin_panels
 - uber::plugin_bands
 - uber::plugin_hotel
 - uber::plugin_tabletop
-
-# magfest prime event-specific settings
+- uber::plugin_magfest
 
 uber::plugins::extra_plugins:
-  magprime:
-    git_repo: 'https://github.com/magfest/magprime'
-    git_branch: 'master'
   mivs:
     git_repo: 'https://github.com/magfest/mivs'
     git_branch: 'master'
@@ -286,6 +284,10 @@ uber::config::volunteer_checklist:
 uber::config::dept_head_overrides:
   - 'challenges = "Orvie Thumel / Daniel Hill / Bunny Smith / Michael Ridgaway"'
 
+# TODO: changeme: these are the same forms as magprime 2016 (last year)
+uber::plugin_magfest::treasury_dept_checklist_form_url:   "https://docs.google.com/spreadsheets/d/1v-jZ7NPIgpR0-wsfZFOTKJJbKDUrd-xVIgf0mTTbjtM/edit#gid=799868163"
+uber::plugin_magfest::techops_dept_checklist_form_url:    "https://magops.wufoo.com/forms/tech-requirements-form/"
+
 uber::config::dept_head_checklist:
   creating_shifts:
     deadline: "2015-11-17"
@@ -300,12 +302,12 @@ uber::config::dept_head_checklist:
     name: "MPoint Needs"
     deadline: "2015-12-15"
     description: "Tell us whether you need any mpoints for your department."
-    path: "/magprime_dept_checklist/treasury"
+    path: "/magfest_dept_checklist/treasury"
   allotments:
     name: "Treasury Information"
     deadline: "2015-12-15"
     description: "If you need cash and/or mpoints, tell us your department schedule and your specific cash needs."
-    path: "/magprime_dept_checklist/allotments"
+    path: "/magfest_dept_checklist/allotments"
   approve_setup_teardown:
     name: "Approve/Decline Requests to Help With Setup/Teardown"
     deadline: "2015-12-22"
@@ -334,7 +336,7 @@ uber::config::dept_head_checklist:
     name: "Tech Requirements"
     deadline: "2015-12-29"
     description: "What do you need in terms of laptops, projectors, cables, internet access, etc?"
-    path: "/magprime_dept_checklist/tech_requirements"
+    path: "/magfest_dept_checklist/tech_requirements"
   postcon_hours:
     name: "(After the Event) Marking and Rating Shifts"
     deadline: "2016-03-01"


### PR DESCRIPTION
- fix dept head checklist to use new magfest plugin urls
- fix some dates per brent's request

this PR replaces https://github.com/magfest/production-config/pull/58
merge after https://github.com/magfest/magfest/pull/1 and https://github.com/magfest/ubersystem-puppet/pull/94
