### PR TITLE
Updated DH Checklist and Department listings

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -149,7 +149,6 @@ uber::config::job_interests:
   shedspace: "Jam Clinic"
   jamspace: "Jam Space"
   lan: "LAN"
-  lanlounge: "LAN Events"
   larp: "LARP"
   panels: "Panels"
   regdesk: "Regdesk"
@@ -159,7 +158,6 @@ uber::config::job_interests:
   tabletop: "Tabletop"
   tech_ops: "Tech Ops"
   tea_room: "Tea Room"
-  
 
 uber::config::job_locations:
   console: "Consoles"
@@ -284,11 +282,11 @@ uber::config::volunteer_checklist:
   5: 'signups/shifts_item.html'
 
 uber::config::dept_head_overrides:
-  - 'challenges = "Orvie Thumel / Daniel Hill / Bunny Smith / Michael Ridgaway"'
+  - 'challenges = "Orvie Thumel / Daniel Hill / Bunny Smith"'
 
 uber::config::dept_head_checklist:
   creating_shifts:
-    deadline: "2016-10-17"
+    deadline: "2016-10-25"
     description: "STOPS is happy to assist you in creating shifts. Since the days of the week are different than M13, we recomend only using M13 as a simple guideline.  Please let us know if you need assistance with this step."
     path: "/jobs/index?location={department}"
   assigned_volunteers:
@@ -317,13 +315,13 @@ uber::config::dept_head_checklist:
     description: "Double check that everyone in your department who you know needs hotel space has requested it."
     path: "/hotel/index?department={department}"
   printed_signs:
-    deadline: "2016-12-05"
+    deadline: "2016-12-06"
     description: "Other than a sign for your area, what printed signs/banners/forms do you need?"
   office_supplies:
-    deadline: "2016-12-05"
+    deadline: "2016-12-06"
     description: "Do you need any paper, pens, sharpies, tripods, whiteboards, scissors, staplers, etc?"
   custom_ribbons:
-    deadline: "2016-12-05"
+    deadline: "2016-12-06"
     description: "Besides the ribbons given out at registration, you may need your own ribbon type to help manage access to certain restricted areas. If so, please let us know what they should say, how many you'll need, and what color you'd like them to be. These ribbons will be given to you at the beginning of MAGFest to distribute to whoever needs them.  (Note: Small orders of ribbons are very expensive - please request a ribbon type only if you need it, and tell us why you need it so we can make sure there's no duplication between departments.)"
   placeholders:
     name: "Checking Placeholder Registrations"
@@ -337,7 +335,7 @@ uber::config::dept_head_checklist:
     path: "/magprime_dept_checklist/tech_requirements"
   postcon_hours:
     name: "(After the Event) Marking and Rating Shifts"
-    deadline: "2017-02-01"
+    deadline: "2017-01-24"
     description: "After the weekend is over, we'll want all department heads to ensure that their volunteers had their shifts marked and rated."
     path: "/jobs/signups?location=59983785"
 


### PR DESCRIPTION
Initial pass on DH Checklist dates - makes them all on a Tuesday of their corresponding weeks for consistency.
Removed LAN Events as a department listing (They will be run from wthin LAN for 2017)
