### PR TITLE
Changing DH checklist dates

### DIFF
--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -198,22 +198,22 @@ uber::plugin_magfest::techops_dept_checklist_form_url:    "https://docs.google.c
 
 uber::config::dept_head_checklist:
   creating_shifts:
-    deadline: "2016-08-06"
+    deadline: "2016-08-08"
     description: "STOPS is happy to assist you in creating shifts, if you aren't making any changes, we can use the shifts from MAGClassic.  Please let us know if you need assistance with this step or what changes you have."
     path: "/jobs/index?location={department}"
   assigned_volunteers:
     name: "Volunteers Assigned to Your Department"
-    deadline: "2016-08-06"
+    deadline: "2016-08-08"
     description: "Check all of the volunteers currently assigned to your department to make sure no one is missing AND that no one is there who shouldn't be."
     path: "/jobs/staffers?location={department}"
   treasury:
     name: "MPoint Needs"
-    deadline: "2016-08-06"
+    deadline: "2016-08-08"
     description: "Tell us whether you need any mpoints for your department."
     path: "/magfest_dept_checklist/treasury"
   allotments:
     name: "Treasury Information"
-    deadline: "2016-08-06"
+    deadline: "2016-08-08"
     description: "If you need cash and/or mpoints, tell us your department schedule and your specific cash needs."
     path: "/magfest_dept_checklist/allotments"
   hotel_eligible:


### PR DESCRIPTION
Any Department Heads's added after the initial deadline for portions of the checklist, will not get emails pertaining to that section.
The edit resets the deadlines for the first 3 items so DH that were named today will see them.
