### PR TITLE
add new config settings for donation tiers

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -68,15 +68,41 @@ uber::config::post_con: 'False'
 
 uber::config::donation_tier:
   No thanks: 0
-  Ribbon: 5
-  Button: 10
-  Shirt: SHIRT_LEVEL
-  Guitar Keychain: 40
+  T-Shirt Bundle: SHIRT_LEVEL
+  I <3 Magfest: 50
   Supporter Package: SUPPORTER_LEVEL
-  Battery Pack: 100
-  Season Pass: SEASON_LEVEL
-  Canvas Art Print: 250
-  Decorative Air Guitar: 500
+  Vampire: 200
+  #### enable the stuff below later in the year ####
+  # Wall Meat: 500
+  # Disembodied Department Head: 1000
+
+# everything in here must match the "name" of something from donation_tier
+uber::config::donation_tier_descriptions:
+  no_thanks:
+    name: "No thanks"
+    icon: "http://something.com"
+    description: "No thanks"
+    link: "../static_views/supporters.html"
+  shirt:
+    name: "T-Shirt Bundle"
+    icon: "http://something.com"
+    description: "Shirt bundle etc"
+    link: "../static_views/supporters.html"
+  i_heart_magfest:
+    name: "I <3 Magfest"
+    icon: "http://something.com"
+    description: "Necklace thing squarewave stuff"
+    link: "../static_views/supporters.html"
+  supporter_package:
+    name: "Supporter Package"
+    icon: "http://something.com"
+    description: "A BUNCH OF STUFF"
+    link: "../static_views/supporters.html"
+  vampire:
+    name: "Vampire"
+    icon: "http://something.com"
+    description: "Better than a stake through the heart"
+    link: "../static_views/supporters.html"
 
 uber::config::badge_enums:
   attendee_badge:         "Attendee"

--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -80,27 +80,27 @@ uber::config::donation_tier:
 uber::config::donation_tier_descriptions:
   no_thanks:
     name: "No thanks"
-    icon: "http://something.com"
+    icon: "http://placehold.it/50x50?text=icon"
     description: "No thanks"
     link: "../static_views/supporters.html"
   shirt:
     name: "T-Shirt Bundle"
-    icon: "http://something.com"
+    icon: "http://placehold.it/50x50?text=icon"
     description: "Shirt bundle etc"
     link: "../static_views/supporters.html"
   i_heart_magfest:
     name: "I <3 Magfest"
-    icon: "http://something.com"
+    icon: "http://placehold.it/50x50?text=icon"
     description: "Necklace thing squarewave stuff"
     link: "../static_views/supporters.html"
   supporter_package:
     name: "Supporter Package"
-    icon: "http://something.com"
+    icon: "http://placehold.it/50x50?text=icon"
     description: "A BUNCH OF STUFF"
     link: "../static_views/supporters.html"
   vampire:
     name: "Vampire"
-    icon: "http://something.com"
+    icon: "http://placehold.it/50x50?text=icon"
     description: "Better than a stake through the heart"
     link: "../static_views/supporters.html"
 


### PR DESCRIPTION
- remove default donation tier values, will never use them again
- these values will be used for more robust display of kickin info

merge vs pretty_syntax branch which cleans up stuff in prep for this PR.

merge AFTER https://github.com/magfest/ubersystem-puppet/pull/99
