### PR TITLE
fix option to be the required 'no shirt' all lowercase value

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -253,7 +253,7 @@ uber::config::supporter_level: 80
 uber::config::season_level: 160
 
 uber::config::shirt_sizes:
-  Select a size: 0
+  no shirt: 0               # MUST BE 'no shirt' all lowercase or things break
   S Unisex: 1
   M Unisex: 2
   L Unisex: 3


### PR DESCRIPTION
fixes https://github.com/magfest/magprime/issues/144

turns out this needs to say EXACTLY 'no shirt' to work.

I suspect we could also change the dropdown to say 'select a shirt size' in the future, but this at least makes it non-broken.
