### PR TITLE
add config option: hardcore_optimizations_enabled

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -20,6 +20,10 @@ uber::plugins::extra_plugins:
     git_repo: 'https://github.com/magfest/attendee_tournaments'
     git_branch: 'master'
 
+# optimizations designed for handling the heaviest load, use for magprime prereg launch
+# disable after the first launch is done
+uber::config::hardcore_optimizations_enabled: 'True'
+
 uber::config::priority_plugins: "uber, panels, bands"
 
 uber::plugin_hotel::hotel_req_hours: 30


### PR DESCRIPTION
- use these for extreme server load cases, these enable extremely aggressive and potentially breaking optimizations
- never use this unless you know EXACTLY what you're doing, and you have no other choice because your server's face is melting

merge with 
https://github.com/magfest/ubersystem-puppet/pull/102
https://github.com/magfest/ubersystem/pull/1971
