### PR TITLE
Change max badge count to 19000

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -63,7 +63,7 @@ uber::config::dealer_reg_deadline: '2016-08-21 20'    # after this date, applica
 uber::config::dealer_reg_shutdown: '2016-08-21 23'       # after this date, no new applications allowed
 uber::config::dealer_payment_due: '2016-12-15'        # dealers must pay by this date
 
-uber::config::max_badge_sales: 20000
+uber::config::max_badge_sales: 19000
 
 uber::plugin_panels::hide_schedule: 'True'
 


### PR DESCRIPTION
Since the badge cap doesn't include comped badges, we actually want it to be a bit under 20k.

For reference, we sold 18799 badges last year, and the event was pretty heavily crowded. Another 1k+ people will likely be too many for attendees' comfort.
