### PR TITLE
Changes to Staff Room deadline

### DIFF
--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -37,7 +37,7 @@ uber::config::uber_takedown: '2016-09-11'
 
 uber::config::placeholder_deadline: '2016-09-09'
 uber::config::supporter_deadline: '2016-08-20'
-uber::config::room_deadline: '2016-08-13'
+uber::config::room_deadline: '2016-08-19'
 uber::config::shirt_deadline: '2016-08-20'
 uber::config::printed_badge_deadline: '2016-08-12'
 uber::config::shifts_created: '2016-08-06'


### PR DESCRIPTION
So we have had a certain percentage of staff that haven't request room space yet, we are setting back the deadline by 6 days so we can re-mail that information.
