### PR TITLE
use plugin_barcode

### DIFF
--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -1,6 +1,7 @@
 ---
 classes:
 - roles::uber_server
+- uber::plugin_barcode
 - uber::plugin_panels
 - uber::plugin_bands
 - uber::plugin_hotel

--- a/event-magstock.yaml
+++ b/event-magstock.yaml
@@ -1,6 +1,7 @@
 ---
 classes:
 - roles::uber_server
+- uber::plugin_barcode
 - uber::plugin_panels
 - uber::plugin_bands
 - uber::plugin_magfest

--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -3,6 +3,7 @@
 
 classes:
 - roles::uber_server
+- uber::plugin_barcode
 - uber::plugin_panels
 - uber::plugin_bands
 - uber::plugin_hotel


### PR DESCRIPTION
- previously this was hardcoded in the puppet module, now we have to explicitly include it
