### PR TITLE
rename maglabs ssl CA client cert

### DIFF
--- a/event-labs-production.yaml
+++ b/event-labs-production.yaml
@@ -1,4 +1,4 @@
 ---
 # our own CA cert for use with our API
 # this is not related to normal SSL on port 443 for normal web traffic, only for our JSON-RPC API
-uber::nginx::ssl_ca_crt: "puppet:///modules/uber/magclassic-ca.crt"
+uber::nginx::ssl_ca_crt: "puppet:///modules/uber/maglabs-ca.crt"


### PR DESCRIPTION
we re-issued the certs on the server side so need this

this is not for normal SSL, this is client-side CRTs for the json-rpc api
