### PR TITLE
Add age group discounts

### DIFF
--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -89,6 +89,10 @@ uber::config::badge_types:
     range_start: 6000
     range_end: 7999
 
+uber::config::age_groups:
+  under_13:
+    discount: 10
+
 uber::config::initial_attendee: 40    # badge price
 uber::config::dealer_badge_price: 20
 uber::config::max_dealers: 10


### PR DESCRIPTION
Adds the ability to define age groups to puppet and re-adds the $10 discount for MAGLabs, which was taken out accidentally.
