### PR TITLE
migrate ubersystem onsite with these settings

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -16,6 +16,8 @@ uber::config::event_timezone: "US/Eastern"
 uber::config::contact_url: 'http://magfest.org/contact'
 uber::config::consent_form_url: 'http://magfest.org/minorconsentform'
 
+uber::nginx::onsite_uber_address: 'https://onsite.uber.magfest.org' # leave off trailing slash
+
 uber::config::kiosk_cc_enabled: True
 
 uber::config::shirt_sizes:

--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -52,7 +52,7 @@ uber::config::max_badge_sales: 2000
 
 uber::plugin_panels::hide_schedule: 'True'
 
-uber::config::at_the_con: 'False'
+uber::config::at_the_con: 'True'   # WHEN SETTING THIS BACK TO FALSE, MAKE SURE TO SET post_con=TRUE, remove AWS keys
 
 uber::config::out_of_shirts: 'False'
 

--- a/external/labs.uber.magfest.org.yaml
+++ b/external/labs.uber.magfest.org.yaml
@@ -1,0 +1,13 @@
+---
+classes:
+- uber::db_replication_slave
+
+# ----------------------
+# database replication
+# ----------------------
+
+uber::db::replication_mode:                         slave
+# uber::db_replication_master::replication_password:  [PASSWORD]   # this is set in the mcp secret settings
+uber::db_replication_slave::replicate_from:         rams1.uber.magfest.org
+
+# --------------

--- a/external/labs.uber.magfest.org.yaml
+++ b/external/labs.uber.magfest.org.yaml
@@ -11,3 +11,5 @@ uber::db::replication_mode:                         slave
 uber::db_replication_slave::replicate_from:         rams1.uber.magfest.org
 
 # --------------
+
+uber::nginx::redirect_all_traffic_onsite: True

--- a/external/rams1.uber.magfest.org.yaml
+++ b/external/rams1.uber.magfest.org.yaml
@@ -1,6 +1,18 @@
 ---
-uber::config::at_the_con: 'True'
 # uber::config::post_con: 'True'
 
 # set this so that onsite emails from the onsite server have the correct base URL
 uber::config::url_base: 'https://labs.uber.magfest.org/uber'
+
+
+classes:
+- uber::db_replication_master
+
+# ----------------------
+# database replication
+# ----------------------
+
+uber::db::replication_mode:                         master
+# uber::db_replication_master::replication_password:  [PASSWORD]   # this is set in the mcp secret settings
+uber::db_replication_master::allow_to_hosts:
+ - labs.uber.magfest.org


### PR DESCRIPTION
do 3 things:
1) put all labs ubers in at_the_con mode
2) enable database replication from onsite rams1.uber to cloud labs.uber
3) via nginx, redirect all traffic from labs.uber to onsite.uber

merge https://github.com/magfest/ubersystem-puppet/pull/116 first
merge only when ready to actually deploy
