### PR TITLE
Stop hiding the Labs schedule

### DIFF
--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -50,7 +50,7 @@ uber::config::dealer_payment_due: '2016-09-01'        # dealers must pay by this
 
 uber::config::max_badge_sales: 2000
 
-uber::plugin_panels::hide_schedule: 'True'
+uber::plugin_panels::hide_schedule: 'False'
 
 uber::config::at_the_con: 'True'   # WHEN SETTING THIS BACK TO FALSE, MAKE SURE TO SET post_con=TRUE, remove AWS keys
 


### PR DESCRIPTION
Once https://github.com/magfest/panels/pull/32 is merged, we'll have the schedule redirect to the Guidebook schedule, but this only works if hide_schedule is False.
