### PR TITLE
Adds: merch_contractor: "Yetee Staff" as a Department

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -234,6 +234,7 @@ uber::config::job_locations:
   mages: "MAGES"
   marketplace: "Marketplace"
   merch: "Merchandise"
+  merch_contractor: "Yetee Staff"
   mops: "MEDIATRON!"
   museum: "Museum"
   nga: "Nexus Gaming Alliance"
@@ -254,7 +255,7 @@ uber::config::job_locations:
   tea_room: "Tea Room"
   zombie_tag: "Zombie Tag"
 
-uber::config::shiftless_depts: "dorsai,marketplace,nga,simulations"
+uber::config::shiftless_depts: "dorsai,marketplace,nga,simulations,merch_contractor"
 
 uber::config::shirt_level: 20
 uber::config::supporter_level: 80


### PR DESCRIPTION
This change reflects updates with a Merch contractor.
Allows for merch_contractor to a department, with Shiftless hours - primarily for staff badges and room allocation tracking.
Also builds for future variables: merch_contractor: "Yetee Staff"  
merch_contractor is the stable heading, and we change the name of the contractor "Yetee Staff" to whatever contractor we have in the future.
