### PR TITLE
Update Band Plugin info per email.

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -405,14 +405,14 @@ uber::plugin_bands::band_email_signature: '- MAGFest Music Department'
 
 uber::plugin_bands::auction_start:            '2017-01-08 11' # placeholder
 
-uber::plugin_bands::band_panel_deadline:      '2016-11-01 08'
-uber::plugin_bands::band_bio_deadline:        '2016-09-01 08'
-uber::plugin_bands::band_agreement_deadline:  '2016-09-25 08'
-uber::plugin_bands::band_w9_deadline:         '2016-09-25 08'
-uber::plugin_bands::band_merch_deadline:      '2016-10-01 08'
-uber::plugin_bands::band_charity_deadline:    '2016-11-05 08'
-uber::plugin_bands::band_badge_deadline:      '2016-10-10 08'
-uber::plugin_bands::stage_agreement_deadline: '2016-10-15 08'
+uber::plugin_bands::band_panel_deadline:      '2016-10-31'
+uber::plugin_bands::band_bio_deadline:        '2016-10-24'
+uber::plugin_bands::band_agreement_deadline:  '2016-10-24'
+uber::plugin_bands::band_w9_deadline:         '2016-10-31'
+uber::plugin_bands::band_merch_deadline:      '2016-11-07' 
+uber::plugin_bands::band_charity_deadline:    '2016-12-15'
+uber::plugin_bands::band_badge_deadline:      '2016-12-15'
+uber::plugin_bands::stage_agreement_deadline: '2016-11-14'
 
 uber::plugin_bands::band_merch_enums:
   no_merch:     "Not selling merch"


### PR DESCRIPTION
Updates all the Band plugin-dates except:
uber::plugin_bands::band_merch_deadline:      '2016-11-07' 
(Set to 7 days after W9 deadline following the example from previous dates.
