### PR TITLE
Changing techops requirements form url

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -343,7 +343,7 @@ uber::config::dept_head_overrides:
 
 # TODO: changeme: these are the same forms as magprime 2016 (last year)
 uber::plugin_magfest::treasury_dept_checklist_form_url:   "https://docs.google.com/spreadsheets/d/1v-jZ7NPIgpR0-wsfZFOTKJJbKDUrd-xVIgf0mTTbjtM/edit#gid=799868163"
-uber::plugin_magfest::techops_dept_checklist_form_url:    "https://magops.wufoo.com/forms/tech-requirements-form/"
+uber::plugin_magfest::techops_dept_checklist_form_url:    "http://techops.magfe.st/requirements"
 
 uber::config::dept_head_checklist:
   creating_shifts:


### PR DESCRIPTION
People are starting to submit requirements to the old form URL.  Changing this now so that any early birds will go to the right place, even as we work out kinks with the form.
