### PR TITLE
Move Supporter deadline to match printed name deadline

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -54,7 +54,7 @@ uber::config::group_prereg_takedown: '2017-01-03'
 uber::config::uber_takedown: '2017-01-07'
 
 uber::config::placeholder_deadline: '2016-12-26'
-uber::config::supporter_deadline: '2016-11-29'
+uber::config::supporter_deadline: '2016-11-23'
 uber::config::shirt_deadline: '2016-12-15'
 uber::config::printed_badge_deadline: '2016-11-23'
 


### PR DESCRIPTION
It doesn't really make sense to allow people to buy supporter packs after they can no longer set their custom badge name.

The deadline may need to be even further back - I'd like BoD/exec approval for this so we can also blast it on social media. @nickthenewbie1 in particular