### PR TITLE
Updates Staff Badge range

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -131,7 +131,7 @@ uber::config::extra_ribbon_types:
 
 uber::config::badge_types:
   staff_badge:
-    range_start: 152
+    range_start: 50
     range_end: 999
   supporter_badge:
     range_start: 1000


### PR DESCRIPTION
We have DH's tying to enter staff badges and getting error messages:
"when I try to select staff badges, it tells me there are no more of that type?"

Current Value: gives us 847 staff badges.
staff_badge: range_start: 152 range_end: 999

We need that closer to 1000
@dom @eli