### PR TITLE
Added Con/fest ops to shiftless deparments

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -258,7 +258,8 @@ uber::config::job_locations:
   tea_room: "Tea Room"
   zombie_tag: "Zombie Tag"
 
-uber::config::shiftless_depts: "dorsai,marketplace,simulations,merch_contractor"
+uber::config::shiftless_depts: "dorsai,marketplace,simulations,merch_contractor,con_ops" 
+#Con/Fest Ops primarily used for Outside Contractors - Signage, Light/Sound production, these are groups we pay but still want in the system.
 
 uber::config::shirt_level: 20
 uber::config::supporter_level: 80


### PR DESCRIPTION
We have certain groups that we pay to help with MAGFest - we still want to issue them a badge, but aren't so worried about shift hours etc.   That includes things like Sign maker, Light/Sound production (Nomad in this case), etc.