### PR TITLE
add "other" for job interest on frontpage reg page

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -206,6 +206,7 @@ uber::config::job_interests:
   tabletop: "Tabletop"
   tech_ops: "Tech Ops"
   tea_room: "Tea Room"
+  other: "Other"
 
 uber::config::job_locations:
   console: "Consoles"


### PR DESCRIPTION
This should work.  It adds "other" for job interest on the frontpage when you check "volunteering"

![image](https://cloud.githubusercontent.com/assets/5413064/20545637/3ee03084-b0de-11e6-865d-bb11c96acda3.png)


@bds002 asked for this