### PR TITLE
add more staff badges by cutting into supporter badges

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -132,9 +132,9 @@ uber::config::extra_ribbon_types:
 uber::config::badge_types:
   staff_badge:
     range_start: 25
-    range_end: 999
+    range_end: 1799
   supporter_badge:
-    range_start: 1000
+    range_start: 1800
     range_end: 1999
   guest_badge:
     range_start: 2000
@@ -206,6 +206,7 @@ uber::config::job_interests:
   tabletop: "Tabletop"
   tech_ops: "Tech Ops"
   tea_room: "Tea Room"
+  other: "Other"
 
 uber::config::job_locations:
   console: "Consoles"


### PR DESCRIPTION
should be ok now. @kitsuta or @EliAndrewC I definitely need a second set of eyes on this.

We're out of staff badges again.  We could create some more in that badge range by reducing the number of "supporter badge"s and increasing the number of staff badges.

In theory we should not actually have ANY actual badges of type "supporter", instead we should only have attendee badges where ```attendee.kickin>c.SUPPORTER_LEVEL```.

To verify this:

existing config was: 
```
supporter_badge:
    range_start: 1000
    range_end: 1999
```
and when I do 
```SELECT * FROM Attendee WHERE badge_num >= 1000 AND badge_num <= 1999;``` 

it yields no results, as I was expecting

I -think- this change is safe to make.  Just want a sanity check before we do it.