### PR TITLE
Add an extra day to supporter deadline

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -50,7 +50,7 @@ uber::config::group_prereg_takedown: '2017-01-03'
 uber::config::uber_takedown: '2017-01-07'
 
 uber::config::placeholder_deadline: '2016-12-26'
-uber::config::supporter_deadline: '2016-11-29'
+uber::config::supporter_deadline: '2016-11-30'
 uber::config::shirt_deadline: '2016-12-15'
 uber::config::printed_badge_deadline: '2016-11-22'
 


### PR DESCRIPTION
We want this to be at the end of the month because that makes more sense than the day before the end of the month.