### PR TITLE
Fix yaml

### DIFF
--- a/external/staging3.uber.magfest.org.yaml
+++ b/external/staging3.uber.magfest.org.yaml
@@ -1,5 +1,8 @@
 ---
 
+# YAML files really don't like it when you don't include anything.  annoying.  put this in here to make it happy.
+placeholder_only: 'do not remove this line if there is nothing else in the config file'
+
 # fake at-the-con mode to test on-site reg functionality
 # uber::config::at_the_con: 'True'
 


### PR DESCRIPTION
Turns out I broke this a few days ago and we didn't do any deploys since then so no one noticed til just now.

Our YAML files weirdly don't like to be empty, so we need a placeholder item to keep them happy.

This might be some artifact related to the ```----``` at the top, we may not need that and it might make this thing not happen.  It bears further investigation later.  For now, this'll fix it.