### PR TITLE
remove old placeholder date

### DIFF
--- a/event-prime-development.yaml
+++ b/event-prime-development.yaml
@@ -1,2 +1,3 @@
 ---
-uber::config::prereg_open: '1999-09-09'  # fake prereg open early on dev boxes
+placeholder_needed____feel_free_to_remove_this: 'you can remove this once anything is else is added to the file'
+# uber::config::prereg_open: '1999-09-09'  # fake prereg open early on dev boxes


### PR DESCRIPTION
- we don't need it anymore, was for testing only

this was causing some issues when testing new email sending features since emails rely on the dates