### PR TITLE
disable emails while we mess with groups

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -28,6 +28,8 @@ uber::config::hardcore_optimizations_enabled: 'False'
 
 uber::config::priority_plugins: "uber, panels, bands"
 
+uber::config::send_emails:      'False'   # TEMPORARILY DISABLED FOR MAINTENANCE DEPLOY
+
 uber::plugin_hotel::hotel_req_hours: 30
 
 uber::config::room_deadline: '2016-11-29'


### PR DESCRIPTION
we're doing some maintenance that involves changing people's statuses and don't want them to get bad emails in the time between we deploy and when we fix the DB (cost info)