### PR TITLE
Reverse the polarity of the over_13 ribbon

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -127,7 +127,7 @@ uber::config::donations_enabled: true
 
 uber::config::extra_ribbon_types:
   band: "RockStar"
-  over_13: "Between 13 and 18"
+  under_13: "Under 13"
 
 uber::config::badge_types:
   staff_badge:

--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -127,6 +127,7 @@ uber::config::donations_enabled: true
 
 uber::config::extra_ribbon_types:
   band: "RockStar"
+  over_13: "Between 13 and 18 (unused)"
   under_13: "Under 13"
 
 uber::config::badge_types:

--- a/event-west.yaml
+++ b/event-west.yaml
@@ -122,7 +122,7 @@ uber::config::donations_enabled: true
 
 uber::config::extra_ribbon_types:
   band: "RockStar"
-  over_13: "Between 13 and 18"
+  under_13: "Under 13"
 
 uber::config::badge_types:
   staff_badge:


### PR DESCRIPTION
To reflect changes in reg workflow, we need to assign the formerly-named 'over 13' ribbon only to attendees UNDER 13. This makes the necessary changes. Fixes https://github.com/magfest/ubersystem/issues/2237.