### PR TITLE
enable onsite replication settings for onsite mode for supermag

### DIFF
--- a/external/rams1.uber.magfest.org.yaml
+++ b/external/rams1.uber.magfest.org.yaml
@@ -1,15 +1,15 @@
 ---
 # set this so that onsite emails from the onsite server have the correct base URL
-uber::config::url_base: 'https://labs.uber.magfest.org/uber'
+uber::config::url_base: 'https://super2017.uber.magfest.org/uber'
 
 # ----------------------
 # database replication
 # ----------------------
 
-# classes:
-# - uber::db_replication_master
+classes:
+- uber::db_replication_master
 
-# uber::db::replication_mode:                         master
+uber::db::replication_mode:                         master
 # uber::db_replication_master::replication_password:  [PASSWORD]   # this is set in the mcp secret settings
-#uber::db_replication_master::allow_to_hosts:
-# - labs.uber.magfest.org
+uber::db_replication_master::allow_to_hosts:
+- super2017.uber.magfest.org

--- a/external/super2017.uber.magfest.org.yaml
+++ b/external/super2017.uber.magfest.org.yaml
@@ -1,0 +1,18 @@
+---
+
+# ----------------------
+# database replication
+# ----------------------
+
+classes:
+- uber::db_replication_slave
+
+uber::db::replication_mode:                         slave
+# uber::db_replication_master::replication_password:  [PASSWORD]   # this is set in the mcp secret settings
+uber::db_replication_slave::replicate_from:         rams1.uber.magfest.org
+
+# --------------
+
+uber::nginx::redirect_all_traffic_onsite: True
+
+test_only_delete_this_later: True # not sure why we need this but we do.


### PR DESCRIPTION
enable onsite mode for super magfest servers
- enable replication
- redirect all traffic from super2017.uber.magfest.org to onsite.uber.magfest.org