### PR TITLE
Remove barcode scanning plugin

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -21,9 +21,6 @@ uber::plugins::extra_plugins:
   reports:
     git_repo: 'https://github.com/magfest/reports'
     git_branch: 'master'
-  barcode_scanning:
-    git_repo: 'https://github.com/magfest/barcode-scanning'
-    git_branch: 'master'
 
 # optimizations designed for handling the heaviest load, use for magprime prereg launch flood.
 # disable after the first launch is done.


### PR DESCRIPTION
We don't need this and it's tripping erroneously for users who are typing. Might as well remove it wholesale.