### PR TITLE
Magstock 2017 final update

### DIFF
--- a/event-magstock.yaml
+++ b/event-magstock.yaml
@@ -39,7 +39,7 @@ uber::config::supporter_deadline: '2017-05-20'
 uber::config::shifts_created: '2017-06-06'    # change to whatever date shifts were imported
 uber::config::uber_takedown: '2017-06-08'
 
-uber::config::max_badge_sales: 550   # review this as we get closer to cap
+uber::config::max_badge_sales: 450   # review this as we get closer to cap
 
 uber::config::at_the_con: 'False'
 uber::config::post_con: 'False'
@@ -136,8 +136,8 @@ uber::config::coming_as_types:
 # number of people allowed to buy meals.
 # this number does NOT include people who get free meals automatically like: staff badges, performers, and their +1s
 # the amount of meals we need to serve may end up ~40 higher than this number.
-uber::config::food_stock: 101       # only affects MAGSTOCK instances
-uber::config::food_price: 20        # only affects MAGSTOCK instances
+uber::config::food_stock: 150       # only affects MAGSTOCK instances
+uber::config::food_price: 25        # only affects MAGSTOCK instances
 
 uber::config::supporter_stock: 50
 uber::config::supporter_level: 50


### PR DESCRIPTION
Changed badge cap to 450 from 550 per history
Changed meal cap to 150 from 101 per user request (CNLohr)
Changed food_price from 20 to 25 per user request (CNLohr)