### PR TITLE
Fixes #192: sets use_checkin_barcode to False for magstock deployment

### DIFF
--- a/event-magstock.yaml
+++ b/event-magstock.yaml
@@ -25,6 +25,8 @@ uber::config::year: 7
 uber::config::event_venue: 'Small Country Campground'
 uber::config::event_venue_address: '4400 Byrd Mill Road, Louisa, VA 23093'
 
+uber::config::use_checkin_barcode: False
+
 uber::config::groups_enabled: 'False'
 uber::config::kiosk_cc_enabled: True
 


### PR DESCRIPTION
I think this is all I need to change. But can someone else take a look and tell me if I'm missing anything, or did something wrong...

Help! I need an adult!