### PR TITLE
Make the Magstock config plugin match other plugins

### DIFF
--- a/event-magstock.yaml
+++ b/event-magstock.yaml
@@ -8,9 +8,6 @@ classes:
 - uber::plugin_magstock
 
 uber::plugins::extra_plugins:
-  magstock:
-    git_repo: 'https://github.com/magfest/magstock'
-    git_branch: 'master'
   reports:
     git_repo: 'https://github.com/magfest/reports'
     git_branch: 'master'


### PR DESCRIPTION
This is largely a style change. Goes with https://github.com/magfest/ubersystem-puppet/pull/131.