### PR TITLE
update event-west.yaml supporter tiers and dates

### DIFF
--- a/event-west.yaml
+++ b/event-west.yaml
@@ -44,7 +44,7 @@ uber::config::epoch: '2017-08-25 08'
 uber::config::eschaton: '2017-08-27 18'
 
 uber::config::hide_prereg_open_date: 'True'
-uber::config::prereg_open: '2017-06-30 16'
+uber::config::prereg_open: '2017-04-19 16'
 uber::config::prereg_takedown: '2017-08-24'
 uber::config::group_prereg_takedown: '2018-08-22'
 uber::config::uber_takedown: '2017-08-22'
@@ -57,8 +57,8 @@ uber::config::printed_badge_deadline: '2017-07-25'
 uber::config::shifts_created: '2016-03-01'   # TODO: set this once we import, if we do.
 
 uber::config::dealer_reg_start: '2017-04-01 20'       # dealer reg not allowed before this date
-uber::config::dealer_reg_deadline: '2017-05-01 20'    # after this date, applications are auto-waitlisted
-uber::config::dealer_reg_shutdown: '2017-06-01 23'       # after this date, no new applications allowed
+uber::config::dealer_reg_deadline: '2017-06-01 20'    # after this date, applications are auto-waitlisted
+uber::config::dealer_reg_shutdown: '2017-07-01 23'       # after this date, no new applications allowed
 uber::config::dealer_payment_due: '2017-07-30'        # dealers must pay by this date
 
 uber::config::max_badge_sales: 2000   # set low for starters, bump up as needed
@@ -76,7 +76,7 @@ uber::config::donation_tier:
   T-Shirt Bundle: SHIRT_LEVEL
   # I <3 Magfest: 50
   Supporter Package: SUPPORTER_LEVEL
-  Golden Bagel: 200
+  # Golden Bagel: 200
   #### enable the stuff below later in the year ####
   # Wall Meat: 500
   # Disembodied Department Head: 1000
@@ -98,11 +98,6 @@ uber::config::donation_tier_descriptions:
     icon: "../static/icons/star.png"
     description: "Personalized Keepsake |Swag Bag"
     link: "../static_views/keepsakebadge.html|../static_views/swagbag.html"
-  vampire:
-    name: "Golden Bagel"
-    icon: "../static/icons/menace.png"
-    description: "Bagel of Power|Some Crazy Shit"
-    link: "../static_views/morecowbell.html|../static_views/secrets.html"
 
 uber::config::badge_enums:
   attendee_badge:         "Attendee"
@@ -163,10 +158,10 @@ uber::config::badge_prices:
     Sunday: 25
 
   attendee:
-    '2017-03-01': 55
-    '2017-05-01': 60
+    '2017-05-01': 55
+    '2017-06-01': 60
     '2017-07-01': 65
-    '2017-08-24': 70
+    '2017-08-01': 70
     #4000: 55
     #5000: 60
     #6000: 65
@@ -181,20 +176,20 @@ uber::config::job_interests:
   arcade: "Arcade"
 #  challenges: "Challenges Booth"
   charity: "Charity"
-#  chipspace: "Chipspace"
+  chipspace: "Chipspace"
   concert: "Main Theater Operations"
   console: "Consoles"
 #  film_fest: "Film Festival"
 #  indie_games: "Indie Showcase"
 #  shedspace: "Jam Clinic"
   jamspace: "Jam Space"
-#  lan: "LAN"
+  lan: "LAN"
 #  larp: "LARP"
 #  museum: "Museum"
   panels: "Panels"
   regdesk: "Regdesk"
   security: "Security"
-  food_prep: "Staff Suite"
+#  food_prep: "Staff Suite"
   staff_support: "Staff Support"
   tabletop: "Tabletop"
   tech_ops: "Tech Ops"


### PR DESCRIPTION
Removed Golden Bagel kick-in level. Updated the pre-reg open dates, as well as the badge price increase dates. I'm alright with using a dropdown instead of these big buttons for the tiers, but if that is too difficult could we grab the icons and html pages from this year's super mag? A link to where I can edit those would be much appreciated.