### PR TITLE
MAGStock 7: Updating Start Epoch

### DIFF
--- a/event-magstock.yaml
+++ b/event-magstock.yaml
@@ -27,7 +27,7 @@ uber::config::use_checkin_barcode: False
 uber::config::groups_enabled: 'False'
 uber::config::kiosk_cc_enabled: True
 
-uber::config::epoch: '2017-06-08 18'
+uber::config::epoch: '2017-06-08 14'
 uber::config::eschaton: '2017-06-11 18'
 uber::config::prereg_open: '2017-03-19 15'
 uber::config::prereg_takedown: '2017-06-07'


### PR DESCRIPTION
Doing so to unlock some shifts from requiring setup privileges.