### PR TITLE
Set 'use_checkin_barcode' to True

### DIFF
--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -28,6 +28,8 @@ uber::config::year: 2017
 uber::config::event_venue: 'The Hilton Alexandria Mark Center'
 uber::config::event_venue_address: '5000 Seminary Rd, Alexandria, VA 22311'
 
+uber::config::use_checkin_barcode: 'True'
+
 uber::config::groups_enabled: 'True'
 uber::config::group_discount: 5,
 

--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -41,6 +41,8 @@ uber::config::consent_form_url: 'http://magfest.org/parentalconsentform'
 uber::config::event_venue: 'The Gaylord National Hotel and Convention Center'
 uber::config::event_venue_address: '201 Waterfront St, National Harbor, MD 20745'
 
+uber::config::use_checkin_barcode: 'True'
+
 uber::config::epoch: '2018-01-05 08'
 uber::config::eschaton: '2018-01-08 18'
 

--- a/event-west.yaml
+++ b/event-west.yaml
@@ -41,6 +41,8 @@ uber::config::event_venue: 'The Hyatt Regency Santa Clara'
 uber::config::event_venue_address: '5101 Great America Pkwy, Santa Clara, CA 95054'
 uber::config::event_timezone: 'US/Pacific'
 
+uber::config::use_checkin_barcode: 'True'
+
 uber::config::epoch: '2017-08-25 08'
 uber::config::eschaton: '2017-08-27 18'
 


### PR DESCRIPTION
Since we now set this to False in configspec.ini (https://github.com/magfest/ubersystem/pull/2558), Labs, West, and Prime need to override that.