### PR TITLE
Clarifies wording of approve_setup_teardown step in department head checklist

### DIFF
--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -268,7 +268,7 @@ uber::config::dept_head_checklist:
     description: "What do you need in terms of laptops, projectors, cables, internet access, etc?"
     path: "/magfest_dept_checklist/tech_requirements"
   approve_setup_teardown:
-    name: "Approve/Decline additional hotel nights to help with Setup/Teardown"
+    name: "Approve/Decline Additional Hotel Nights to Help With Setup/Teardown"
     deadline: "2017-08-11"
     description: "An overwhelming majority of staffers want to work setup and teardown shifts rather than work during the event itself, so we have far more offers than we have need for.  Since this affects what hotel nights staffers get, please approve and decline requests for this for people in your department."
     path: "/hotel/requests?department={department}"

--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -268,7 +268,7 @@ uber::config::dept_head_checklist:
     description: "What do you need in terms of laptops, projectors, cables, internet access, etc?"
     path: "/magfest_dept_checklist/tech_requirements"
   approve_setup_teardown:
-    name: "Approve/Decline Requests to Help With Setup/Teardown"
+    name: "Approve/Decline additional hotel nights to help with Setup/Teardown"
     deadline: "2017-08-11"
     description: "An overwhelming majority of staffers want to work setup and teardown shifts rather than work during the event itself, so we have far more offers than we have need for.  Since this affects what hotel nights staffers get, please approve and decline requests for this for people in your department."
     path: "/hotel/requests?department={department}"

--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -380,7 +380,7 @@ uber::config::dept_head_checklist:
     description: "If you need cash and/or mpoints, tell us your department schedule and your specific cash needs."
     path: "/magfest_dept_checklist/allotments"
   approve_setup_teardown:
-    name: "Approve/Decline Requests to Help With Setup/Teardown"
+    name: "Approve/Decline additional hotel nights to help with Setup/Teardown"
     deadline: "2017-11-22"
     description: "An overwhelming majority of staffers want to work setup and teardown shifts rather than work during the event itself, so we have far more offers than we have need for.  Since this affects what hotel nights staffers get, please approve and decline requests for this for people in your department."
     path: "/hotel/requests?department={department}"

--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -183,7 +183,7 @@ uber::config::badge_prices:
     '2018-01-06': 55  # Day 3
     '2018-01-07': 20  # Day 4
     3000: 69  # First bucket based price bump
-    6000: 79  
+    6000: 79
     10500: 85
 
 uber::config::shift_custom_badges: true
@@ -380,7 +380,7 @@ uber::config::dept_head_checklist:
     description: "If you need cash and/or mpoints, tell us your department schedule and your specific cash needs."
     path: "/magfest_dept_checklist/allotments"
   approve_setup_teardown:
-    name: "Approve/Decline additional hotel nights to help with Setup/Teardown"
+    name: "Approve/Decline Additional Hotel Nights to Help With Setup/Teardown"
     deadline: "2017-11-22"
     description: "An overwhelming majority of staffers want to work setup and teardown shifts rather than work during the event itself, so we have far more offers than we have need for.  Since this affects what hotel nights staffers get, please approve and decline requests for this for people in your department."
     path: "/hotel/requests?department={department}"

--- a/event-west.yaml
+++ b/event-west.yaml
@@ -339,7 +339,7 @@ uber::config::dept_head_checklist:
     description: "If you need cash and/or mpoints, tell us your department schedule and your specific cash needs."
     path: "/magfest_dept_checklist/allotments"
   approve_setup_teardown:
-    name: "Approve/Decline additional hotel nights to help with Setup/Teardown"
+    name: "Approve/Decline Additional Hotel Nights to Help With Setup/Teardown"
     deadline: "2017-08-01"
     description: "An overwhelming majority of staffers want to work setup and teardown shifts rather than work during the event itself, so we have far more offers than we have need for.  Since this affects what hotel nights staffers get, please approve and decline requests for this for people in your department."
     path: "/hotel/requests?department={department}"

--- a/event-west.yaml
+++ b/event-west.yaml
@@ -339,7 +339,7 @@ uber::config::dept_head_checklist:
     description: "If you need cash and/or mpoints, tell us your department schedule and your specific cash needs."
     path: "/magfest_dept_checklist/allotments"
   approve_setup_teardown:
-    name: "Approve/Decline Requests to Help With Setup/Teardown"
+    name: "Approve/Decline additional hotel nights to help with Setup/Teardown"
     deadline: "2017-08-01"
     description: "An overwhelming majority of staffers want to work setup and teardown shifts rather than work during the event itself, so we have far more offers than we have need for.  Since this affects what hotel nights staffers get, please approve and decline requests for this for people in your department."
     path: "/hotel/requests?department={department}"
@@ -379,7 +379,7 @@ uber::config::dept_head_overrides:
 
 uber::config::peglegs_sig: |
     - MAGFest Director of Panel Operations
-    
+
 uber::config::panels_email: 'MAGWest Panels <panels@magwest.org>'
 
 uber::plugin_bands::band_email:           'MAGWest Music Department <music@magwest.org>'


### PR DESCRIPTION
Per gdreyband's request on slack. I agree, the old wording was a little confusing.