### PR TITLE
Remove under 13 discount for Labs

### DIFF
--- a/event-labs.yaml
+++ b/event-labs.yaml
@@ -118,10 +118,6 @@ uber::config::badge_types:
     range_start: 6000
     range_end: 7999
 
-uber::config::age_groups:
-  under_13:
-    discount: 10
-
 uber::config::initial_attendee: 50    # badge price
 uber::config::dealer_badge_price: 20
 uber::config::max_dealers: 10


### PR DESCRIPTION
This discount is replaced by half-price child badges in our magfest/ plugin, and the config option being here creates confusing text on the checkout page.