### PR TITLE
Updates MIVS deadlines

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -474,6 +474,7 @@ uber::plugin_bands::band_merch_enums:
 
 
 uber::plugin_mivs::round_one_deadline:    "2017-09-03"
+uber::plugin_mivs::video_response_expected: "by September 16th"
 uber::plugin_mivs::round_two_deadline:    "2017-09-30"
 uber::plugin_mivs::judging_deadline:      "2017-10-29"
 uber::plugin_mivs::round_two_complete:    "2017-11-05"

--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -473,10 +473,10 @@ uber::plugin_bands::band_merch_enums:
   rock_island:  "Rock Island" # comment out this line to disable rock island in band agreement / plugin
 
 
-uber::plugin_mivs::round_one_deadline:    "2017-09-10"
-uber::plugin_mivs::round_two_deadline:    "2017-10-10"
-uber::plugin_mivs::judging_deadline:      "2017-10-30"
-uber::plugin_mivs::round_two_complete:    "2017-10-30"
+uber::plugin_mivs::round_one_deadline:    "2017-09-03"
+uber::plugin_mivs::round_two_deadline:    "2017-09-30"
+uber::plugin_mivs::judging_deadline:      "2017-10-29"
+uber::plugin_mivs::round_two_complete:    "2017-11-05"
 uber::plugin_mivs::mivs_confirm_deadline: "2017-11-16"
 
-uber::plugin_mivs::allow_game_submission: True
+# uber::plugin_mivs::allow_game_submission: True


### PR DESCRIPTION
Fixes https://github.com/magfest/production-config/issues/277.

MIVS_CONFIRM_DEADLINE wasn't specified, so was left as-is -- it is the deadline given to winners of the showcase to tell the MIVS team that they can't make it after all. I expect we'll want it to be more than 7 days after the showcase announcement.

I also turned off ALLOW_GAME_SUBMISSION because the plugin's configspec.ini (https://github.com/magfest/mivs/blob/master/mivs/configspec.ini#L2) indicates that we want the game fields hidden until the second round.