### PR TITLE
Enables promo codes for Super MAGFest

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -46,6 +46,7 @@ uber::config::event_venue: 'The Gaylord National Hotel and Convention Center'
 uber::config::event_venue_address: '201 Waterfront St, National Harbor, MD 20745'
 
 uber::config::use_checkin_barcode: 'True'
+uber::config::badge_promo_codes_enabled: True
 
 # The number of hours after prereg_open that the "Request Hotel Booking Info"
 # checkbox will be available (168 = 1 week x 7 days x 24 hours, probably need to adjust with final timing)


### PR DESCRIPTION
Enables promo codes for Super MAGFest per @nickthenewbie1's request. This will make it easier to give discounts to organizations like the Veterans Association.