### PR TITLE
added MITS plugin to list of extra plugins

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -21,6 +21,9 @@ uber::plugins::extra_plugins:
   reports:
     git_repo: 'https://github.com/magfest/reports'
     git_branch: 'master'
+  mits:
+    git_repo: 'https://github.com/magfest/mits'
+    git_branch: 'master'
 
 # optimizations designed for handling the heaviest load, use for magprime prereg launch flood.
 # disable after the first launch is done.


### PR DESCRIPTION
I didn't add a new puppet class for MITS since for now that isn't necessary or useful, but I can add one down the road if we start wanting to actually expose and change its config options.

Once this is merged we'll be able to confirm that this deploys cleanly on staging and I'll re-run through a quick test of all of the different pages and features to make sure that everything works as well as it does on my local Vagrant and then we can hopefully make it go live to production this weekend.