### PR TITLE
Update Mega Man-athon Year Number

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -388,7 +388,7 @@ uber::config::event_locations:
  # magolympics: "Grand Championship" not happing in 2018
   zombie_tag: "Zombie Tag (Magnolia 2)"
   escape_room: "Escape Room (Baltimore 1,2)"
-  MegaManathon: "Mega Man-athon 5 (Maryland Hallway)"
+  MegaManathon: "Mega Man-athon 6 (Maryland Hallway)"
 
 uber::config::volunteer_checklist:
   4: 'hotel_requests/hotel_item.html'


### PR DESCRIPTION
Super MAGFest 2018 will be Mega Man-athon 6. Edited as appropriate.