### PR TITLE
Add MIVS indie ribbon and remove 13-18 ribbon

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -172,8 +172,8 @@ uber::config::donations_enabled: true
 
 uber::config::extra_ribbon_types:
   band: "RockStar"
-  over_13: "Between 13 and 18 (unused)"
   under_13: "Under 13"
+  mivs: "MIVS Indie"
 
 uber::config::badge_types:
   staff_badge:


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/3046.

Also, we only kept the 13 to 18 ribbon last year because it was attached to some attendees -- it's not attached to anyone right now so we can go ahead and remove it.