### PR TITLE
Rename "MIVS Indie" ribbon to "Indie Dev"

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -173,7 +173,7 @@ uber::config::donations_enabled: true
 uber::config::extra_ribbon_types:
   band: "RockStar"
   under_13: "Under 13"
-  mivs: "MIVS Indie"
+  mivs: "Indie Dev"
 
 uber::config::badge_types:
   staff_badge:


### PR DESCRIPTION
The physical ribbons say "Indie Dev" and we are going to use them for both MITS and MIVS, so the ribbon label in uber should reflect that.