### PR TITLE
added merch_items fields to [donation_tier_descriptions] subsections

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -149,11 +149,13 @@ uber::config::donation_tier_descriptions:
     icon: "../static/icons/supporter.png"
     description: "Super Swag Bag|Swadge"
     link: "../static_views/super_swag_bag.html|../static_views/swadge.html"
+    merch_items: "Supporter Swag Bag"
   super_star:
     name: "Super Star"
     icon: "../static/icons/super_star.png"
     description: "Star Rod Wand|Star Umbrella|Invitation"
     link: "../static_views/star_rod_wand.html|../static_views/star_umbrella.html|../static_views/invitation.html"
+    merch_items: "Star Wand, Star Umbrella"
 
 uber::config::badge_enums:
   attendee_badge:         "Attendee"


### PR DESCRIPTION
This goes with https://github.com/magfest/ubersystem/pull/3093 but this PR and that one can be merged in any order.  If this was merged and deployed first, we'd just have an unused config option which wouldn't hurt anything.  If the other PR was merged first, we'd just have the default empty values for each of the tiers, causing us to fall back on the ``description`` value.