### PR TITLE
removed supporter merch item override

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -149,7 +149,6 @@ uber::config::donation_tier_descriptions:
     icon: "../static/icons/supporter.png"
     description: "Super Swag Bag|Swadge"
     link: "../static_views/super_swag_bag.html|../static_views/swadge.html"
-    merch_items: "Supporter Swag Bag"
   super_star:
     name: "Super Star"
     icon: "../static/icons/super_star.png"


### PR DESCRIPTION
I thought that regresk handed out swadges, so I defined a ``merch_items`` for the Supporter level which didn't have the swadge.  It turns out that the merch booth DOES hand out the swadges, so there's no reason to define a ``merch_items`` field at all for the Supporter level, because the ``description`` field already contains exactly what we need.  So I just removed it.

I'm gonna merge this right away since it's such a small change and it'll help Nick test this out, since he's poking around to make sure things are ready for this evening.  Obviously I'll test on staging before deploying to production.