### PR TITLE
Add only_prepay_at_door option

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -50,6 +50,7 @@ uber::config::event_venue_address: '201 Waterfront St, National Harbor, MD 20745
 
 uber::config::use_checkin_barcode: 'True'
 uber::config::badge_promo_codes_enabled: True
+uber::config::only_prepay_at_door: True
 
 # The number of hours after prereg_open that the "Request Hotel Booking Info"
 # checkbox will be available (168 = 1 week x 7 days x 24 hours, probably need to adjust with final timing)


### PR DESCRIPTION
Requested by registration so they can turn on at-con mode without needing payment stations set up. We do this instead of just changing the door_payment_method opts because it is impossible to take away enum options via puppet.