### PR TITLE
Remove "I'm in a group" option on at-door page

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -35,7 +35,7 @@ uber::plugin_hotel::hotel_req_hours: 30
 
 uber::config::room_deadline: '2017-11-29'
 
-uber::config::groups_enabled: True
+uber::config::groups_enabled: False
 uber::config::collect_extra_donation: True
 
 uber::config::event_name: 'MAGFest'


### PR DESCRIPTION
This is only to be merged if/when Reg gives the green light.

This takes away the ability for attendees to say they're in a group when they're registering at a kiosk. It turns out that reg doesn't (seem to) use this workflow for unassigned group badges, so they (probably) want it turned off to reduce confusion.

I checked the code, and despite its name, this config setting only controls at-door payment opts.