### PR TITLE
Bumps max_badge_sales to 20000

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -97,7 +97,7 @@ uber::config::staff_eligible_for_swag_shirt: False
 
 uber::config::badge_price_waived: '2018-01-07 12'
 
-uber::config::max_badge_sales: 19000
+uber::config::max_badge_sales: 20000
 
 uber::plugin_panels::hide_schedule: false
 


### PR DESCRIPTION
Should be safe. We have 20000 physical attendee badges, and there are usually between 700-1000 no-shows.

There's another ubersystem pull request incoming that does more precise max_badge_sales calculation.