### PR TITLE
fixed badge ranges to account for possible M13 badges handed out

### DIFF
--- a/event-prime.yaml
+++ b/event-prime.yaml
@@ -97,7 +97,7 @@ uber::config::staff_eligible_for_swag_shirt: False
 
 uber::config::badge_price_waived: '2018-01-07 12'
 
-uber::config::max_badge_sales: 20000
+uber::config::max_badge_sales: 21000
 
 uber::plugin_panels::hide_schedule: false
 
@@ -185,9 +185,9 @@ uber::config::badge_types:
     range_end: 2999
   guest_badge:
     range_start: 3000
-    range_end: 9999
+    range_end: 3600
   attendee_badge:
-    range_start: 10000
+    range_start: 3601
     range_end: 39999
   one_day_badge:
     range_start: 40000


### PR DESCRIPTION
This makes two changes:

1) We're adjusting the ranges for Attendee and Guest badges.  If we run out of attendee badges this year, then we'll be using M13 attendee badges in the range of 3601 - 9999, which does NOT overlap with any actual badge we have this year.

2) Based on some math, we've determine that if we raise the cap on badges sold to 21k and then actually hit that then we'll end up with about 22k people on-site, which is roughly what we've said we're comfortable with.  I can go into the numbers if anyone's interested.  (21000 + 642 + 1121 + 602 - 335 - 1251 = ~21779 people on-site, and I can go into what each of those numbers are for anyone who cares.  We might bump this up slightly again if it looks like we'll hit it and we decide we can take the extra capacity)