### PR TITLE
Adds regdesk to labs2018

### DIFF
--- a/external/labs2018.uber.magfest.org.yaml
+++ b/external/labs2018.uber.magfest.org.yaml
@@ -159,6 +159,7 @@ uber::config::job_locations:
   dorsai: "Dorsai"
   mops: "Mediatron!"
   merch: "Merchandise"
+  regdesk: "Regdesk"
   rescuers: "Rescuers"
   security: "Security"
   staff_support: "Staff Support"

--- a/external/staging3.uber.magfest.org.yaml
+++ b/external/staging3.uber.magfest.org.yaml
@@ -159,6 +159,7 @@ uber::config::job_locations:
   dorsai: "Dorsai"
   mops: "Mediatron!"
   merch: "Merchandise"
+  regdesk: "Regdesk"
   rescuers: "Rescuers"
   security: "Security"
   staff_support: "Staff Support"


### PR DESCRIPTION
`c.REGDESK` is referenced in the source code, so the variable must be present.