### PR TITLE
turn hide_schedule to false for magwest

### DIFF
--- a/event-west-2018.yaml
+++ b/event-west-2018.yaml
@@ -64,7 +64,7 @@ uber::config::dealer_payment_due: ''        # dealers must pay by this date
 
 uber::config::max_badge_sales: 2000   # set low for starters, bump up as needed
 
-uber::config::hide_schedule: 'True'
+uber::config::hide_schedule: 'False'
 
 uber::config::panel_app_deadline: '2018-07-03'
 uber::config::expected_response: 'July 2018'


### PR DESCRIPTION
We're ready to publish the schedule, I -think- this is the right setting for enabling the schedule to be public yea?

What is the right URL to use for linking the public to the published uber schedule?