### PR TITLE
set hide_schedule to false

### DIFF
--- a/event-west-2018.yaml
+++ b/event-west-2018.yaml
@@ -64,7 +64,7 @@ uber::config::dealer_payment_due: ''        # dealers must pay by this date
 
 uber::config::max_badge_sales: 2000   # set low for starters, bump up as needed
 
-uber::config::hide_schedule: 'True'
+uber::config::hide_schedule: 'False'
 
 uber::config::panel_app_deadline: '2018-07-03'
 uber::config::expected_response: 'July 2018'


### PR DESCRIPTION
merge after https://github.com/magfest/ubersystem/pull/3255 which addresses the previous issue with admin data getting cached in the output